### PR TITLE
Refactor package identifiers to reuse repositories and clean up on install

### DIFF
--- a/gitpkg/cli.py
+++ b/gitpkg/cli.py
@@ -520,18 +520,27 @@ Commands:
 
         tree = Tree("Package update results:")
 
+        updated_packages: dict[str, PkgUpdateResult] = {}
+
         with console.status("[bold green]Updating packages...") as status:
             for dest, pkg in to_install:
-                pkg_name = self._render_package_name(dest, pkg)
-                status.update(f"[bold green]Updating {pkg_name}...")
+                pkg_ident = self._pm.package_identifier(dest, pkg)
 
-                stats_before_update = self._pm.package_stats(dest, pkg)
-                update_result = self._pm.update_package(
-                    dest,
-                    pkg,
-                    discard_untracked_changes=args.force,
-                    check_only=args.check,
-                )
+                # there is no need to update a repo again if two
+                # packages share it
+                if pkg_ident not in updated_packages:
+                    pkg_name = self._render_package_name(dest, pkg)
+                    status.update(f"[bold green]Updating {pkg_name}...")
+
+                    stats_before_update = self._pm.package_stats(dest, pkg)
+                    updated_packages[pkg_ident] = self._pm.update_package(
+                        dest,
+                        pkg,
+                        discard_untracked_changes=args.force,
+                        check_only=args.check,
+                    )
+
+                update_result = updated_packages[pkg_ident]
 
                 pkg_name = self._render_package_name(dest, pkg)
 

--- a/gitpkg/config.py
+++ b/gitpkg/config.py
@@ -13,7 +13,6 @@ class PkgConfig:
     package_root: str
     updates_disabled: bool = False
     branch: str = None
-    install_method: str = None
 
 
 @dataclass
@@ -45,8 +44,6 @@ class Config:
                     lines.append("updates-disabled = true")
                 if pkg.branch:
                     lines.append(f'branch = "{pkg.branch}"')
-                if pkg.install_method and pkg.install_method in ["link"]:
-                    lines.append(f'install-method = "{pkg.install_method}"')
                 lines.append("")
 
         for dest in self.destinations:

--- a/gitpkg/errors.py
+++ b/gitpkg/errors.py
@@ -81,8 +81,3 @@ class PackageRootDirNotFoundError(GitPkgError):
 class NameInvalidError(GitPkgError):
     def __init__(self, name: str):
         super().__init__(f"Name '{name}' is not valid!")
-
-
-class InvalidInstallMethodError(GitPkgError):
-    def __init__(self, install_method: str):
-        super().__init__(f"Invalid install method: {install_method}")

--- a/gitpkg/pkg_manager.py
+++ b/gitpkg/pkg_manager.py
@@ -284,7 +284,7 @@ class PkgManager:
             else:
                 self._remove_pkg_from_gitmodules(destination, pkg)
                 self._repo.create_submodule(
-                    name=self._package_ident(destination, pkg),
+                    name=self.package_identifier(destination, pkg),
                     path=submodule_location,
                     url=pkg.url,
                     branch=pkg.branch,
@@ -387,7 +387,7 @@ class PkgManager:
         for dest_name in self._config.packages:
             for pkg in self._config.packages[dest_name]:
                 dest = self.find_destination(dest_name)
-                ident = self._package_ident(dest, pkg)
+                ident = self.package_identifier(dest, pkg)
 
                 if ident not in packages:
                     packages.append(ident)
@@ -460,7 +460,7 @@ class PkgManager:
             cp.write()
 
     def _repo_used_by_other_pkg(self, dest: Destination, pkg: PkgConfig) -> bool:
-        package_ident = self._package_ident(dest, pkg)
+        package_ident = self.package_identifier(dest, pkg)
 
         for ref_dest in self.destinations():
             for ref_pkg in self.find_packages_by_destination(ref_dest):
@@ -468,7 +468,7 @@ class PkgManager:
                 if dest.name == ref_dest.name and pkg.name == ref_pkg.name:
                     continue
 
-                ref_ident = self._package_ident(ref_dest, ref_pkg)
+                ref_ident = self.package_identifier(ref_dest, ref_pkg)
 
                 if package_ident == ref_ident:
                     return True
@@ -478,7 +478,7 @@ class PkgManager:
         self, destination: Destination, pkg: PkgConfig
     ) -> None:
         """Remove package entry from the .gitmodules file"""
-        pkg_ident = self._package_ident(destination, pkg)
+        pkg_ident = self.package_identifier(destination, pkg)
         gitmodules_file = self.project_root_directory() / ".gitmodules"
         section = f'submodule "{pkg_ident}"'
 
@@ -494,7 +494,7 @@ class PkgManager:
                 gitmodules_file.unlink()
 
     def _update_gitmodules_file(self, destination: Destination, pkg: PkgConfig) -> None:
-        pkg_ident = self._package_ident(destination, pkg)
+        pkg_ident = self.package_identifier(destination, pkg)
         gitmodules_file = self.project_root_directory() / ".gitmodules"
         section = f'submodule "{pkg_ident}"'
 
@@ -535,9 +535,9 @@ class PkgManager:
         pkg: PkgConfig,
     ) -> Path:
         """Submodule location of package"""
-        return self._gitpkgs_location() / self._package_ident(destination, pkg)
+        return self._gitpkgs_location() / self.package_identifier(destination, pkg)
 
-    def _package_ident(self, _dest: Destination, pkg: PkgConfig) -> str:
+    def package_identifier(self, _dest: Destination, pkg: PkgConfig) -> str:
         """Unique package identifier"""
         hasher = hashlib.sha3_256()
         hasher.update(
@@ -564,7 +564,7 @@ class PkgManager:
             self.project_root_directory()
             / ".git"
             / "modules"
-            / self._package_ident(destination, pkg)
+            / self.package_identifier(destination, pkg)
         )
 
     @staticmethod

--- a/gitpkg/utils.py
+++ b/gitpkg/utils.py
@@ -1,2 +1,13 @@
+from pathlib import Path
+
+
 def extract_repository_name_from_url(url: str) -> str:
     return url.rstrip("/").rsplit("/", maxsplit=1)[-1].removesuffix(".git")
+
+
+def symlink_exists(path: Path) -> bool:
+    try:
+        path.lstat()
+    except FileNotFoundError:
+        return False
+    return True

--- a/poetry.lock
+++ b/poetry.lock
@@ -91,13 +91,13 @@ tomli = {version = ">=2.0.1,<3.0.0", markers = "python_version < \"3.11\""}
 
 [[package]]
 name = "exceptiongroup"
-version = "1.1.3"
+version = "1.2.0"
 description = "Backport of PEP 654 (exception groups)"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "exceptiongroup-1.1.3-py3-none-any.whl", hash = "sha256:343280667a4585d195ca1cf9cef84a4e178c4b6cf2274caef9859782b567d5e3"},
-    {file = "exceptiongroup-1.1.3.tar.gz", hash = "sha256:097acd85d473d75af5bb98e41b61ff7fe35efe6675e4f9370ec6ec5126d160e9"},
+    {file = "exceptiongroup-1.2.0-py3-none-any.whl", hash = "sha256:4bfd3996ac73b41e9b9628b04e079f193850720ea5945fc96a08633c66912f14"},
+    {file = "exceptiongroup-1.2.0.tar.gz", hash = "sha256:91f5c769735f051a4290d52edd0858999b57e5876e9f85937691bd4c9fa3ed68"},
 ]
 
 [package.extras]
@@ -208,13 +208,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pygments"
-version = "2.17.1"
+version = "2.17.2"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pygments-2.17.1-py3-none-any.whl", hash = "sha256:1b37f1b1e1bff2af52ecaf28cc601e2ef7077000b227a0675da25aef85784bc4"},
-    {file = "pygments-2.17.1.tar.gz", hash = "sha256:e45a0e74bf9c530f564ca81b8952343be986a29f6afe7f5ad95c5f06b7bdf5e8"},
+    {file = "pygments-2.17.2-py3-none-any.whl", hash = "sha256:b27c2826c47d0f3219f29554824c30c5e8945175d888647acd804ddd04af846c"},
+    {file = "pygments-2.17.2.tar.gz", hash = "sha256:da46cec9fd2de5be3a8a784f434e4c4ab670b4ff54d605c4c2717e9d49c4c367"},
 ]
 
 [package.extras]
@@ -311,5 +311,5 @@ files = [
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.10"
-content-hash = "d0268bed2608a9cd6a5b5699ec0079ecf843f66c46b3a1412778b5c73155cf67"
+python-versions = ">=3.10,<4"
+content-hash = "7f4acc467be6c5adb79bd14572650ea29afc781472564c4527203e44ad4e062e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ version = "0.0.0"
 git-pkg = "gitpkg.main:main"
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = ">=3.10,<4"
 gitpython = "^3.1.40"
 dataclass-binder = "^0.3.4"
 rich = "^13.7.0"

--- a/tests/git_composer.py
+++ b/tests/git_composer.py
@@ -20,7 +20,9 @@ class GitComposer:
         if len(prefix_extra) > 0:
             prefix_extra += "_"
 
-        self.temp_dir = Path(tempfile.mkdtemp(prefix=f"gitpkg_{prefix_extra}")).resolve()
+        self.temp_dir = Path(
+            tempfile.mkdtemp(prefix=f"gitpkg_{prefix_extra}")
+        ).resolve()
         self.temp_dir.mkdir(parents=True, exist_ok=True)
 
     def teardown(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,9 @@
 import os
 import shutil
+import sys
 from pathlib import Path
 
 import pytest
-import sys
 
 if sys.version_info < (3, 11):
     import tomli as tomllib  # pragma: no cover
@@ -17,7 +17,7 @@ from gitpkg.config import Config
 from tests.git_composer import GitComposer, checksum
 
 
-def assert_destination_exists(toml: Path, name: str) -> None:
+def assert_toml_dest_exists(toml: Path, name: str) -> None:
     assert toml.exists()
 
     data = tomllib.loads(toml.read_text())
@@ -26,7 +26,7 @@ def assert_destination_exists(toml: Path, name: str) -> None:
     assert len(list(filter(lambda d: d["name"] == name, data["destinations"]))) > 0
 
 
-def assert_package_exists(toml: Path, dest: str, pkg: str) -> None:
+def assert_toml_pkg_exists(toml: Path, dest: str, pkg: str) -> None:
     assert toml.exists()
 
     data = tomllib.loads(toml.read_text())
@@ -64,7 +64,7 @@ class TestCLI:
 
         assert toml_path.exists()
 
-        assert_destination_exists(toml_path, "vendor")
+        assert_toml_dest_exists(toml_path, "vendor")
 
         cli.run([__file__, "dest:list"])
         captured = capsys.readouterr()
@@ -89,8 +89,8 @@ class TestCLI:
 
         assert toml_path.exists()
 
-        assert_destination_exists(toml_path, "libs")
-        assert_package_exists(toml_path, "libs", "remote_repo")
+        assert_toml_dest_exists(toml_path, "libs")
+        assert_toml_pkg_exists(toml_path, "libs", "remote_repo")
 
         assert (vendor_dir / "remote_repo").exists()
 
@@ -110,18 +110,18 @@ class TestCLI:
 
         cli = CLI()
 
-        vendor_dir1 = repo.path() / "libs"
-        vendor_dir1.mkdir(parents=True, exist_ok=True)
+        libs_dir = repo.path() / "libs"
+        libs_dir.mkdir(parents=True, exist_ok=True)
         cli.run([__file__, "dest:register", "libs"])
 
-        vendor_dir2 = repo.path() / "vendor"
-        vendor_dir2.mkdir(parents=True, exist_ok=True)
+        vendor_dir = repo.path() / "vendor"
+        vendor_dir.mkdir(parents=True, exist_ok=True)
         cli.run([__file__, "dest:register", "vendor"])
 
         toml_path = repo.path() / ".gitpkg.toml"
 
-        assert_destination_exists(toml_path, "libs")
-        assert_destination_exists(toml_path, "vendor")
+        assert_toml_dest_exists(toml_path, "libs")
+        assert_toml_dest_exists(toml_path, "vendor")
 
         # test with no dest should raise error
         with pytest.raises(SystemExit) as err:
@@ -133,6 +133,9 @@ class TestCLI:
         cli.run(
             [__file__, "add", str(remote_repo.path().absolute()), "--dest-name", "libs"]
         )
+        # repo should be there
+        assert (libs_dir / "remote_repo").exists()
+
         cli.run(
             [
                 __file__,
@@ -142,9 +145,14 @@ class TestCLI:
                 "vendor",
             ]
         )
+        # repo should be there
+        assert (vendor_dir / "remote_repo").exists()
 
-        assert_package_exists(toml_path, "libs", "remote_repo")
-        assert_package_exists(toml_path, "vendor", "remote_repo")
+        # other repo  should also still be there
+        assert (libs_dir / "remote_repo").exists()
+
+        assert_toml_pkg_exists(toml_path, "libs", "remote_repo")
+        assert_toml_pkg_exists(toml_path, "vendor", "remote_repo")
 
         # installing same package again should cause error
         with pytest.raises(SystemExit) as err:
@@ -192,8 +200,8 @@ class TestCLI:
 
         cli.run([__file__, "add", str(remote_repo.path().absolute()), "-r", "subdir"])
 
-        assert_destination_exists(toml_path, "libs")
-        assert_package_exists(toml_path, "libs", "remote_repo")
+        assert_toml_dest_exists(toml_path, "libs")
+        assert_toml_pkg_exists(toml_path, "libs", "remote_repo")
 
         # test if subdir works
         assert (repo.path() / "libs" / "remote_repo" / "yolo.txt").exists()
@@ -285,13 +293,13 @@ class TestCLI:
 
         toml_path = repo.path() / ".gitpkg.toml"
 
-        assert_destination_exists(toml_path, "libs")
-        assert_package_exists(toml_path, "libs", "depA")
-        assert_package_exists(toml_path, "libs", "depB")
+        assert_toml_dest_exists(toml_path, "libs")
+        assert_toml_pkg_exists(toml_path, "libs", "depA")
+        assert_toml_pkg_exists(toml_path, "libs", "depB")
 
         cli.run([__file__, "remove", "depA"])
 
-        assert_package_exists(toml_path, "libs", "depB")
+        assert_toml_pkg_exists(toml_path, "libs", "depB")
 
         data = tomllib.loads(toml_path.read_text())
         packages = data.get("packages", {}).get("libs", [])
@@ -321,15 +329,15 @@ class TestCLI:
 
         toml_path = repo.path() / ".gitpkg.toml"
 
-        assert_destination_exists(toml_path, "libs")
-        assert_destination_exists(toml_path, "libs2")
+        assert_toml_dest_exists(toml_path, "libs")
+        assert_toml_dest_exists(toml_path, "libs2")
 
-        assert_package_exists(toml_path, "libs", "depA")
-        assert_package_exists(toml_path, "libs2", "depB")
+        assert_toml_pkg_exists(toml_path, "libs", "depA")
+        assert_toml_pkg_exists(toml_path, "libs2", "depB")
 
         cli.run([__file__, "remove", "depA"])
 
-        assert_package_exists(toml_path, "libs2", "depB")
+        assert_toml_pkg_exists(toml_path, "libs2", "depB")
 
         data = tomllib.loads(toml_path.read_text())
 
@@ -382,11 +390,11 @@ class TestCLI:
 
         toml_path = repo.path() / ".gitpkg.toml"
 
-        assert_destination_exists(toml_path, "libs")
-        assert_destination_exists(toml_path, "libs2")
+        assert_toml_dest_exists(toml_path, "libs")
+        assert_toml_dest_exists(toml_path, "libs2")
 
-        assert_package_exists(toml_path, "libs", "the_one")
-        assert_package_exists(toml_path, "libs2", "the_one")
+        assert_toml_pkg_exists(toml_path, "libs", "the_one")
+        assert_toml_pkg_exists(toml_path, "libs2", "the_one")
 
         with pytest.raises(SystemExit) as err:
             cli.run([__file__, "remove", "the_one"])
@@ -395,7 +403,7 @@ class TestCLI:
 
         cli.run([__file__, "remove", "libs2/the_one"])
 
-        assert_package_exists(toml_path, "libs", "the_one")
+        assert_toml_pkg_exists(toml_path, "libs", "the_one")
 
         data = tomllib.loads(toml_path.read_text())
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -244,6 +244,23 @@ class TestCLI:
 
         assert not dep_path.exists()
 
+    def test_add_non_existant_repo(self):
+        repo = self._git.create_repository("test_repo")
+        vendor_dir = repo.path() / "libs"
+        vendor_dir.mkdir(parents=True, exist_ok=True)
+        os.chdir(vendor_dir)
+
+        remote_repo = repo.path().parent / "fake_remote_repo"
+
+        cli = CLI()
+
+        with pytest.raises(Exception) as err:
+            cli.run([__file__, "add", str(remote_repo.absolute()), "-rn", "subdir"])
+
+        dep_path = vendor_dir / "subdir"
+
+        assert not dep_path.exists()
+
     def test_list_packages(self, capsys: CaptureFixture[str]):
         deps = []
 


### PR DESCRIPTION
This fixes #14, #13 and #6